### PR TITLE
Removing magic number, exposing jumpingThreshold.

### DIFF
--- a/Assets/CharacterController2D/Scripts/CharacterController2D.cs
+++ b/Assets/CharacterController2D/Scripts/CharacterController2D.cs
@@ -106,11 +106,11 @@ public class CharacterController2D : MonoBehaviour
 	public float slopeLimit = 30f;
 
 
-    /// <summary>
-    /// the threshold in the change in vertical movement between frames that constitutes jumping
-    /// </summary>
-    /// <value>The jumping threshold.</value>
-    public float jumpingThreshold = 0.07f;
+	/// <summary>
+	/// the threshold in the change in vertical movement between frames that constitutes jumping
+	/// </summary>
+	/// <value>The jumping threshold.</value>
+	public float jumpingThreshold = 0.07f;
 
 
 	/// <summary>


### PR DESCRIPTION
Removing magic number, adding exposed jumpingThreshold so users can toggle the change in vertical movement when a character is jumping - may help issues with jumping on slopes.

Sorry for the multiple formatting commits - my newlines were indenting with spaces instead of tabs. I tried to get it to match up with your formatting.
