### PR TITLE
use cached rigidbody inside CharacterController2D

### DIFF
--- a/Assets/CharacterController2D/Scripts/CharacterController2D.cs
+++ b/Assets/CharacterController2D/Scripts/CharacterController2D.cs
@@ -271,8 +271,8 @@ public class CharacterController2D : MonoBehaviour
 		// move then update our state
 		if( usePhysicsForMovement )
 		{
-			GetComponent<Rigidbody2D>().MovePosition( transform.position + deltaMovement );
-			velocity = GetComponent<Rigidbody2D>().velocity;
+			rigidBody2D.MovePosition( transform.position + deltaMovement );
+			velocity = rigidBody2D.velocity;
 		}
 		else
 		{


### PR DESCRIPTION
This will use the cached `Rigidbody2D` stored in `rigidBody2D` instead of getting it twice each frame with `GetComponent<Rigidbody2D>()`. I think this was a regression caused by the Unity 5 update.