### PR TITLE
Add flushing to horizontal slope handling if not grounded last frame

### DIFF
--- a/Assets/CharacterController2D/CharacterController2D.cs
+++ b/Assets/CharacterController2D/CharacterController2D.cs
@@ -377,9 +377,10 @@ public class CharacterController2D : MonoBehaviour
 					_raycastHitsThisFrame.Add( _raycastHit );
 					// if we weren't grounded last frame, that means we're landing on a slope horizontally.
 					// this ensures that we stay flush to that slope
-					if (!collisionState.wasGroundedLastFrame) {
-						float flushDistance = Mathf.Sign (deltaMovement.x) * (_raycastHit.distance - skinWidth);
-						transform.Translate (new Vector2 (flushDistance, 0));
+					if ( !collisionState.wasGroundedLastFrame )
+					{
+						float flushDistance = Mathf.Sign( deltaMovement.x ) * ( _raycastHit.distance - skinWidth );
+						transform.Translate( new Vector2( flushDistance, 0 ) );
 					}
 					break;
 				}

--- a/Assets/CharacterController2D/CharacterController2D.cs
+++ b/Assets/CharacterController2D/CharacterController2D.cs
@@ -375,6 +375,12 @@ public class CharacterController2D : MonoBehaviour
 				if( i == 0 && handleHorizontalSlope( ref deltaMovement, Vector2.Angle( _raycastHit.normal, Vector2.up ) ) )
 				{
 					_raycastHitsThisFrame.Add( _raycastHit );
+					// if we weren't grounded last frame, that means we're landing on a slope horizontally.
+					// this ensures that we stay flush to that slope
+					if (!collisionState.wasGroundedLastFrame) {
+						float flushDistance = Mathf.Sign (deltaMovement.x) * (_raycastHit.distance - skinWidth);
+						transform.Translate (new Vector2 (flushDistance, 0));
+					}
 					break;
 				}
 


### PR DESCRIPTION
This was a small visual bug I found when attempting to incorporate my own version of this CharacterController. Basically what happens is this:

![image](https://user-images.githubusercontent.com/18194205/46922323-3ccf4380-cfd5-11e8-907e-8a5d81ec3013.png)

You don't become flush to the surface. This only happens with a very specific set of conditions:

- You were not grounded last frame (i.e., "landing")
- You are landing on a slope
- You are moving fast enough horizontally that your horizontal raycasts (and thus, horizontal slope handling) are being hit before your vertical raycasts

Here's an example of what happens to cause it:

- You are moving down + left, i.e., (-x, -y)
- Your left rays detect an upward slope, so deltaMovement gets altered to now be (-x, +y)
- Because y is now positive, your vertical raycasts are now upward
- Because your raycasts are now upward, you don't check below and never become flush to the surface

The solution is actually very simple, as we have all the information we need already. If our horizontal ray index is 0 (first ray), and we hit a slope and handled it--we already check for that to break out of our horizontal slope check loop. All we need to do now is check that we were NOT grounded last frame. We even already have the flush distance--it's the _raycastHit.distance of that horizontal raycast. We just have to subtract skin width and make sure it's in the right direction (left or right).

Then we get this:

![image](https://user-images.githubusercontent.com/18194205/46922371-2aa1d500-cfd6-11e8-8ca8-9c93534e4334.png)

Really loving all this open source stuff. It's helped me a ton, and I'm super happy to have contributed. Even if it's something small like this :)